### PR TITLE
Path planning debug mode

### DIFF
--- a/src/engine/Nodemap.cpp
+++ b/src/engine/Nodemap.cpp
@@ -8,6 +8,14 @@
 #include "Input.h"
 #endif // LOGGING
 
+NodeGrid::~NodeGrid()
+{
+	SDL_DestroyTexture(m_DebugTextureData.m_Texture);
+	SDL_DestroyTexture(m_DebugTextureExploredData.m_Texture);
+	SDL_DestroyTexture(m_DebugTextureStartData.m_Texture);
+	SDL_DestroyTexture(m_DebugTextureEndData.m_Texture);
+}
+
 void NodeGrid::Initialize()
 {
 	auto tilemap_dimensions = Globals::GetTileMapDimensions();
@@ -19,21 +27,25 @@ void NodeGrid::Initialize()
 	int tile_height = tile_size.h;
 
 #ifdef LOGGING
-	auto start_node = m_Nodes.at(40 + (1 * tilemap_dimensions.w));
-	auto end_node = m_Nodes.at(4 + (25* tilemap_dimensions.w));
+	SDL_Point start = { 40,1 };
+	SDL_Point end = { 4,25 };
+
+	auto start_node = m_Nodes.at(start.x + (start.y * tilemap_dimensions.w));
+	auto end_node = m_Nodes.at(end.x + (end.y * tilemap_dimensions.w));
 	CLOCK::StartTimer();
 	auto solution_path = AI::PATH::A_Star(m_Nodes, start_node, end_node);
 	CLOCK::StopTimer("A_Star");
 	
-	m_DebugTextureData = Texture::LoadTexture("ui_foredrop.png");
-	m_DebugTextureExploredData = Texture::LoadTexture("ui_backdrop.png");
+	m_DebugTextureData = Texture::LoadDebugTexture({ 100,100,100,255 }, { 32,32 });
+	m_DebugTextureExploredData = Texture::LoadDebugTexture({ 0,0,255,255 }, { 32,32 });
 	m_DebugNodes.reserve(tilemap_dimensions.w * tilemap_dimensions.w);
+	m_DebugTextureStartData = Texture::LoadDebugTexture({ 0,255,0,255 }, { 32,32 });
+	m_DebugTextureEndData = Texture::LoadDebugTexture({ 255,0,0,255 }, { 32,32 });
 
 	for (int y = 0; y < tilemap_dimensions.h; y++)
 	{
 		for (int x = 0; x < tilemap_dimensions.w; x++)
 		{
-
 			DebugNode node;
 			node.m_TextureData = m_DebugTextureData;
 			node.m_Position = { float(x),float(y) };
@@ -47,6 +59,8 @@ void NodeGrid::Initialize()
 		temp_node.m_TextureData = m_DebugTextureExploredData;
 	}
 
+	m_DebugNodes.at(start.x + (start.y * tilemap_dimensions.w)).m_TextureData.m_Texture = m_DebugTextureStartData.m_Texture;
+	m_DebugNodes.at(end.x + (end.y * tilemap_dimensions.w)).m_TextureData.m_Texture = m_DebugTextureEndData.m_Texture;
 #endif // LOGGING
 }
 

--- a/src/engine/Nodemap.cpp
+++ b/src/engine/Nodemap.cpp
@@ -10,10 +10,12 @@
 
 NodeGrid::~NodeGrid()
 {
+#ifdef LOGGING
 	SDL_DestroyTexture(m_DebugTextureData.m_Texture);
 	SDL_DestroyTexture(m_DebugTextureExploredData.m_Texture);
 	SDL_DestroyTexture(m_DebugTextureStartData.m_Texture);
 	SDL_DestroyTexture(m_DebugTextureEndData.m_Texture);
+#endif // LOGGING
 }
 
 void NodeGrid::Initialize()

--- a/src/engine/Nodemap.h
+++ b/src/engine/Nodemap.h
@@ -18,6 +18,7 @@ public:
 class NodeGrid {
 public:
 	NodeGrid() {}
+	~NodeGrid();
 
 	void Initialize();
 
@@ -34,6 +35,8 @@ public:
 	bool m_DebugActivate = false;
 	Texture::TextureData m_DebugTextureData;
 	Texture::TextureData m_DebugTextureExploredData;
+	Texture::TextureData m_DebugTextureStartData;
+	Texture::TextureData m_DebugTextureEndData;
 	std::vector<DebugNode> m_DebugNodes;
 #endif // LOGGING
 };

--- a/src/engine/Texture.cpp
+++ b/src/engine/Texture.cpp
@@ -37,6 +37,40 @@ namespace Texture {
 		}
 	}
 
+	TextureData LoadDebugTexture(SDL_Colour colour, SDL_Point dimensions)
+	{
+		Uint32 rmask, gmask, bmask, amask;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		rmask = 0xff000000;
+		gmask = 0x00ff0000;
+		bmask = 0x0000ff00;
+		amask = 0x000000ff;
+#else
+		rmask = 0x000000ff;
+		gmask = 0x0000ff00;
+		bmask = 0x00ff0000;
+		amask = 0xff000000;
+#endif
+#ifdef LOGGING
+		std::cout << "Loading debug texture: " << "\n";
+#endif // LOGGING
+		try {
+			SDL_Surface* surface = SDL_CreateRGBSurface(0, 32, 32, 32, rmask, gmask, bmask, amask);
+			SDL_FillRect(surface, NULL, SDL_MapRGBA(surface->format, colour.r, colour.g, colour.b, colour.a));
+			if (surface == nullptr) throw TextureError();
+			SDL_Texture* texture = SDL_CreateTextureFromSurface(Renderer::GetRenderer(), surface);
+			if (texture == nullptr) throw TextureError();
+			SDL_Rect source = { 0,0,surface->w,surface->h };
+			SDL_FreeSurface(surface);
+			return { texture, source };
+		}
+		catch (std::exception& e) {
+			std::cout << "An exception was thrown." << "\n";
+			std::cout << "\t" << e.what() << "\t" << IMG_GetError() << "\n";
+			return {};
+		}
+	}
+
 	void Draw(SDL_Texture* texture, const SDL_Rect& source, const SDL_Rect& destination)
 	{
 		SDL_RenderCopy(Renderer::GetRenderer(), texture, &source, &destination);

--- a/src/engine/Texture.h
+++ b/src/engine/Texture.h
@@ -15,6 +15,7 @@ namespace Texture {
 
 	bool Initialize();
 	TextureData LoadTexture(const char* filename);
+	TextureData LoadDebugTexture(SDL_Colour colour, SDL_Point dimensions);
 	void Draw(SDL_Texture* texture, const SDL_Rect& source, const SDL_Rect& destination);
 } // namespace Texture
 


### PR DESCRIPTION
# Method 
Improved debugging modes to more clearly show start, end and path nodes.

Key: 
- Green (Start node)
- Red (End node)
- Blue (Path)
- Grey (Unused)  
# Evidence 
![image](https://user-images.githubusercontent.com/55410510/195988929-b8996221-ba01-44fe-aa8d-28706d348598.png)
![image](https://user-images.githubusercontent.com/55410510/195989176-16ee1537-45f9-4693-bfd1-27af776a041f.png)
